### PR TITLE
default new birthday date to today's month and day

### DIFF
--- a/components/CreateBirthdayForm.tsx
+++ b/components/CreateBirthdayForm.tsx
@@ -25,10 +25,14 @@ const CreateBirthdayForm = ({ onSubmit }: { onSubmit: () => void }) => {
   const { data: session } = authClient.useSession();
   const [name, setName] = useState("");
 
+  const today = new Date();
+  const defaultMonth = today.getMonth() + 1;
+  const defaultDay = today.getDate();
+
   // NEW: Date component states
   const [year, setYear] = useState<number | null>(null);
-  const [month, setMonth] = useState<number>(1);
-  const [day, setDay] = useState<number>(1);
+  const [month, setMonth] = useState<number>(defaultMonth);
+  const [day, setDay] = useState<number>(defaultDay);
 
   const [category, setCategory] = useState("");
   const [parent, setParent] = useState("");
@@ -85,8 +89,8 @@ const CreateBirthdayForm = ({ onSubmit }: { onSubmit: () => void }) => {
         // Reset form
         setName("");
         setYear(null);
-        setMonth(1);
-        setDay(1);
+        setMonth(defaultMonth);
+        setDay(defaultDay);
         setCategory("");
         setParent("");
         setNotes("");


### PR DESCRIPTION
Previously the create birthday form initialized to January 1 with no
year. Default month/day now reflect today's date so users adding a
birthday on the date itself don't have to change the inputs, while year
remains unset by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the birthday form to default to today's date instead of January 1st when creating a new birthday entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->