### PR TITLE
Redesign sharing flow: tables, readable share page, link-level category

### DIFF
--- a/components/BirthdayDateInput.tsx
+++ b/components/BirthdayDateInput.tsx
@@ -117,15 +117,18 @@ const BirthdayDateInput: FC<BirthdayDateInputProps> = ({
   const maxDays = getDaysInMonth(parsedMonth || 1);
   const dayOptions = Array.from({ length: maxDays }, (_, i) => i + 1);
 
+  const inputClass =
+    "block h-11 w-full rounded-md border border-rule bg-paper px-3 text-sm text-ink placeholder:text-ink-soft focus:border-accent focus:outline-hidden focus:ring-1 focus:ring-accent";
+
   return (
-    <div className="flex flex-col space-y-2">
+    <div className="flex flex-col space-y-1.5">
       {!yearDisabled ? (
         // Date Picker Mode (includes year)
         <div>
           <input
             type="date"
             id={`${idPrefix}-date`}
-            className="block h-12 w-full rounded-sm border-gray-300 text-gray-900"
+            className={inputClass}
             value={dateValue}
             onChange={(e) => {
               const value = e.target.value;
@@ -154,12 +157,12 @@ const BirthdayDateInput: FC<BirthdayDateInputProps> = ({
         </div>
       ) : (
         // Month/Day Dropdowns (no year)
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-2">
           {/* Month Dropdown */}
           <div>
             <select
               id={`${idPrefix}-month`}
-              className="block h-12 w-full rounded-sm border-gray-300 text-gray-900"
+              className={inputClass}
               value={localMonth}
               onChange={(e) => {
                 const newMonth = e.target.value;
@@ -192,7 +195,7 @@ const BirthdayDateInput: FC<BirthdayDateInputProps> = ({
           <div>
             <select
               id={`${idPrefix}-day`}
-              className="block h-12 w-full rounded-sm border-gray-300 text-gray-900"
+              className={inputClass}
               value={localDay}
               onChange={(e) => {
                 const newDay = e.target.value;
@@ -232,11 +235,11 @@ const BirthdayDateInput: FC<BirthdayDateInputProps> = ({
             id={`${idPrefix}-disable-year`}
             checked={yearDisabled}
             onChange={(e) => handleYearToggle(e.target.checked)}
-            className="h-4 w-4 rounded border-gray-300"
+            className="h-4 w-4 rounded border-rule text-accent focus:ring-accent"
           />
           <label
             htmlFor={`${idPrefix}-disable-year`}
-            className="text-sm text-gray-600 cursor-pointer"
+            className="cursor-pointer text-xs text-ink-soft"
           >
             Don&apos;t know the year
           </label>

--- a/components/BirthdaySubmissionForm.tsx
+++ b/components/BirthdaySubmissionForm.tsx
@@ -1,47 +1,10 @@
+import { SUBMIT_BIRTHDAY_MUTATION } from "../graphql/Sharing";
 import BirthdayDateInput from "./BirthdayDateInput";
 import PrimaryButton from "./PrimaryButton";
-import { gql } from "@apollo/client";
 import { useMutation } from "@apollo/client/react";
 import clsx from "clsx";
 import { useState } from "react";
 import toast from "react-hot-toast";
-
-const SUBMIT_BIRTHDAY_MUTATION = gql`
-  mutation SubmitBirthday(
-    $token: String!
-    $name: String!
-    $year: Int
-    $month: Int!
-    $day: Int!
-    $category: String
-    $notes: String
-    $submitterName: String
-    $submitterEmail: String
-    $relationship: String
-  ) {
-    submitBirthday(
-      token: $token
-      name: $name
-      year: $year
-      month: $month
-      day: $day
-      category: $category
-      notes: $notes
-      submitterName: $submitterName
-      submitterEmail: $submitterEmail
-      relationship: $relationship
-    ) {
-      id
-      name
-      year
-      month
-      day
-      date
-      status
-      __typename
-    }
-  }
-`;
 
 interface BirthdayEntry {
   id: string;
@@ -49,8 +12,6 @@ interface BirthdayEntry {
   year: number | null;
   month: number;
   day: number;
-  category: string;
-  relationship: string;
   notes: string;
 }
 
@@ -66,8 +27,6 @@ const createEmptyEntry = (): BirthdayEntry => ({
   year: new Date().getFullYear(),
   month: 1,
   day: 1,
-  category: "",
-  relationship: "",
   notes: "",
 });
 
@@ -132,14 +91,8 @@ const BirthdaySubmissionForm = ({
         }
       }
 
-      if (entry.category.length > 50) {
-        errors.push(`${label}: Category must be 50 characters or less`);
-      }
       if (entry.notes.length > 500) {
         errors.push(`${label}: Notes must be 500 characters or less`);
-      }
-      if (entry.relationship.length > 50) {
-        errors.push(`${label}: Relationship must be 50 characters or less`);
       }
     });
 
@@ -180,9 +133,7 @@ const BirthdaySubmissionForm = ({
               year: entry.year,
               month: entry.month,
               day: entry.day,
-              category: entry.category.trim() || null,
               notes: entry.notes.trim() || null,
-              relationship: entry.relationship.trim() || null,
               submitterName: trimmedSubmitterName,
               submitterEmail: trimmedSubmitterEmail,
             },
@@ -207,9 +158,9 @@ const BirthdaySubmissionForm = ({
     return (
       <div className="py-8 text-center">
         <div className="mb-4">
-          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-emerald-100">
             <svg
-              className="h-8 w-8 text-green-600"
+              className="h-8 w-8 text-emerald-700"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -223,8 +174,10 @@ const BirthdaySubmissionForm = ({
             </svg>
           </div>
         </div>
-        <h2 className="mb-2 text-xl font-semibold text-gray-900">Thank you!</h2>
-        <p className="mb-2 text-gray-600">
+        <h2 className="mb-2 font-display text-xl font-semibold text-ink">
+          Thank you!
+        </h2>
+        <p className="mb-2 text-ink">
           {submittedNames.length === 1
             ? "Your birthday submission has been sent successfully."
             : `${submittedNames.length} birthday submissions have been sent successfully.`}{" "}
@@ -232,10 +185,10 @@ const BirthdaySubmissionForm = ({
           birthday list.
         </p>
         {submittedNames.length > 1 && (
-          <ul className="mb-4 inline-block text-left text-sm text-gray-500">
+          <ul className="mb-4 inline-block text-left text-sm text-ink-soft">
             {submittedNames.map((n, i) => (
               <li key={i} className="flex items-center gap-1.5">
-                <span className="text-green-500">✓</span> {n}
+                <span className="text-emerald-600">✓</span> {n}
               </li>
             ))}
           </ul>
@@ -245,9 +198,9 @@ const BirthdaySubmissionForm = ({
             <button
               onClick={onCancel}
               className={clsx(
-                "inline-flex items-center rounded-md border border-transparent px-4 py-2 font-medium text-gray-700",
-                "hover:bg-gray-100",
-                "focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-hidden",
+                "inline-flex items-center rounded-md border border-rule bg-paper px-4 py-2 font-medium text-ink transition",
+                "hover:bg-paper-deep",
+                "focus:outline-hidden focus:ring-2 focus:ring-accent/40 focus:ring-offset-2",
               )}
             >
               Close
@@ -258,236 +211,192 @@ const BirthdaySubmissionForm = ({
     );
   }
 
+  const inputClass =
+    "block h-11 w-full rounded-md border border-rule bg-paper px-3 text-sm text-ink placeholder:text-ink-soft focus:border-accent focus:outline-hidden focus:ring-1 focus:ring-accent";
+
   return (
-    <div className="mx-auto max-w-2xl">
-      <div className="mb-6">
-        <h1 className="mb-2 text-2xl font-bold text-gray-900">
-          Add Birthdays
-        </h1>
-        <p className="text-gray-600">
-          Help someone keep track of important birthdays by adding the details
-          below.
-        </p>
-      </div>
-
-      <form onSubmit={handleSubmit} className="flex flex-col space-y-4">
-        {entries.map((entry, index) => (
-          <div
-            key={entry.id}
-            className="rounded-md border border-gray-200 p-4"
-          >
-            <div className="mb-3 flex items-center justify-between">
-              <h3 className="text-sm font-semibold text-gray-700">
-                {entries.length > 1
-                  ? entry.name.trim() || `Birthday ${index + 1}`
-                  : "Birthday"}
-              </h3>
-              {entries.length > 1 && (
-                <button
-                  type="button"
-                  onClick={() => removeEntry(entry.id)}
-                  className="text-sm text-gray-400 hover:text-red-500"
-                  aria-label="Remove entry"
-                >
-                  Remove
-                </button>
-              )}
-            </div>
-
-            <div className="grid gap-x-4 md:grid-cols-2">
+    <form onSubmit={handleSubmit} className="flex flex-col space-y-6">
+      <div className="overflow-x-auto">
+        <div className="min-w-[600px] space-y-2 lg:min-w-0">
+          <div className="grid grid-cols-[1.5fr_2fr_2.5fr_2.5rem] gap-x-3 px-2 text-xs font-semibold uppercase tracking-wide text-ink">
+            <div>Name *</div>
+            <div>Birthday *</div>
+            <div>Notes</div>
+            <div className="sr-only">Remove</div>
+          </div>
+          {entries.map((entry, index) => (
+            <div
+              key={entry.id}
+              className="grid grid-cols-[1.5fr_2fr_2.5fr_2.5rem] items-start gap-x-3 gap-y-2 rounded-md border border-rule bg-paper-deep p-2"
+            >
               <div>
-                <label
-                  className="block text-sm font-medium"
-                  htmlFor={`name-${entry.id}`}
-                >
-                  Name *
+                <label className="sr-only" htmlFor={`name-${entry.id}`}>
+                  Name
                 </label>
                 <input
-                  className="mt-1 block h-12 w-full rounded-sm border-gray-300 text-gray-900"
+                  className={inputClass}
                   id={`name-${entry.id}`}
                   onChange={(e) =>
                     updateEntry(entry.id, { name: e.target.value })
                   }
                   type="text"
                   value={entry.name}
-                  placeholder="Enter the person's name"
+                  placeholder="Full name"
                   maxLength={100}
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium">Birthday *</label>
-                <div className="mt-1">
-                  <BirthdayDateInput
-                    idPrefix={`entry-${entry.id}`}
-                    year={entry.year}
-                    month={entry.month}
-                    day={entry.day}
-                    onChange={(year, month, day) =>
-                      updateEntry(entry.id, { year, month, day })
-                    }
-                    required={false}
-                    maxYear={new Date().getFullYear()}
-                  />
-                </div>
-              </div>
-              <div>
-                <label
-                  className="mt-3 block text-sm font-medium"
-                  htmlFor={`category-${entry.id}`}
-                >
-                  Category (optional)
-                </label>
-                <input
-                  className="mt-1 block h-12 w-full rounded-sm border-gray-300 text-gray-900"
-                  id={`category-${entry.id}`}
-                  onChange={(e) =>
-                    updateEntry(entry.id, { category: e.target.value })
+                <label className="sr-only">Birthday</label>
+                <BirthdayDateInput
+                  idPrefix={`entry-${entry.id}`}
+                  year={entry.year}
+                  month={entry.month}
+                  day={entry.day}
+                  onChange={(year, month, day) =>
+                    updateEntry(entry.id, { year, month, day })
                   }
-                  type="text"
-                  value={entry.category}
-                  placeholder="e.g., Family, Friend, Colleague"
-                  maxLength={50}
+                  required={false}
+                  maxYear={new Date().getFullYear()}
                 />
               </div>
               <div>
-                <label
-                  className="mt-3 block text-sm font-medium"
-                  htmlFor={`relationship-${entry.id}`}
-                >
-                  Relationship (optional)
+                <label className="sr-only" htmlFor={`notes-${entry.id}`}>
+                  Notes
                 </label>
                 <input
-                  className="mt-1 block h-12 w-full rounded-sm border-gray-300 text-gray-900"
-                  id={`relationship-${entry.id}`}
+                  className={inputClass}
+                  id={`notes-${entry.id}`}
                   onChange={(e) =>
-                    updateEntry(entry.id, { relationship: e.target.value })
+                    updateEntry(entry.id, { notes: e.target.value })
                   }
                   type="text"
-                  value={entry.relationship}
-                  placeholder="e.g., Sister, Best friend, Coworker"
-                  maxLength={50}
+                  value={entry.notes}
+                  placeholder="Anything to remember"
+                  maxLength={500}
                 />
               </div>
+              <div className="flex h-11 items-center justify-center">
+                {entries.length > 1 ? (
+                  <button
+                    type="button"
+                    onClick={() => removeEntry(entry.id)}
+                    className="flex h-8 w-8 items-center justify-center rounded-md text-ink-soft transition hover:bg-rose-100 hover:text-rose-700"
+                    aria-label={`Remove birthday ${index + 1}`}
+                    title="Remove"
+                  >
+                    <svg
+                      className="h-4 w-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                ) : null}
+              </div>
             </div>
+          ))}
+        </div>
+      </div>
 
-            <div className="mt-3">
-              <label
-                className="block text-sm font-medium"
-                htmlFor={`notes-${entry.id}`}
-              >
-                Notes (optional)
-              </label>
-              <textarea
-                className="mt-1 block w-full rounded-sm border-gray-300 text-gray-900"
-                id={`notes-${entry.id}`}
-                onChange={(e) =>
-                  updateEntry(entry.id, { notes: e.target.value })
-                }
-                value={entry.notes}
-                placeholder="Any additional information or special notes"
-                rows={2}
-                maxLength={500}
-              />
-              <p className="mt-0.5 text-xs text-gray-500">
-                {entry.notes.length}/500 characters
-              </p>
-            </div>
-          </div>
-        ))}
-
-        <button
-          type="button"
-          onClick={addEntry}
-          className={clsx(
-            "flex w-full items-center justify-center gap-2 rounded-md border border-dashed border-gray-300 py-3 text-sm font-medium text-gray-600",
-            "hover:border-gray-400 hover:text-gray-800",
-            "focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 focus:outline-hidden",
-          )}
+      <button
+        type="button"
+        onClick={addEntry}
+        className={clsx(
+          "flex w-full items-center justify-center gap-2 rounded-md border border-dashed border-rule py-3 text-sm font-medium text-ink-soft transition",
+          "hover:border-accent hover:bg-paper-deep hover:text-ink",
+          "focus:outline-hidden focus:ring-2 focus:ring-accent/40 focus:ring-offset-2",
+        )}
+      >
+        <svg
+          className="h-4 w-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
         >
-          <svg
-            className="h-4 w-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M12 4v16m8-8H4"
-            />
-          </svg>
-          Add another birthday
-        </button>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 4v16m8-8H4"
+          />
+        </svg>
+        Add another birthday
+      </button>
 
-        <div className="border-t pt-4">
-          <h3 className="mb-2 text-lg font-medium text-gray-900">
-            Your Information (optional)
-          </h3>
-          <p className="mb-3 text-xs text-gray-500">
-            This helps the recipient know who submitted the birthdays.
-          </p>
-          <div className="grid gap-x-4 md:grid-cols-2">
-            <div>
-              <label
-                className="block text-sm font-medium"
-                htmlFor="submitterName"
-              >
-                Your Name
-              </label>
-              <input
-                className="mt-1 block h-12 w-full rounded-sm border-gray-300 text-gray-900"
-                id="submitterName"
-                onChange={(e) => setSubmitterName(e.target.value)}
-                type="text"
-                value={submitterName}
-                placeholder="Your name"
-                maxLength={100}
-              />
-            </div>
-            <div>
-              <label
-                className="block text-sm font-medium"
-                htmlFor="submitterEmail"
-              >
-                Your Email
-              </label>
-              <input
-                className="mt-1 block h-12 w-full rounded-sm border-gray-300 text-gray-900"
-                id="submitterEmail"
-                onChange={(e) => setSubmitterEmail(e.target.value)}
-                type="email"
-                value={submitterEmail}
-                placeholder="your.email@example.com"
-              />
-            </div>
+      <div className="border-t border-rule pt-6">
+        <h3 className="mb-1 font-display text-lg font-semibold text-ink">
+          Your information (optional)
+        </h3>
+        <p className="mb-3 text-xs text-ink-soft">
+          This helps the recipient know who submitted the birthdays.
+        </p>
+        <div className="grid gap-x-4 gap-y-3 md:grid-cols-2">
+          <div>
+            <label
+              className="mb-1 block text-sm font-medium text-ink"
+              htmlFor="submitterName"
+            >
+              Your name
+            </label>
+            <input
+              className={inputClass}
+              id="submitterName"
+              onChange={(e) => setSubmitterName(e.target.value)}
+              type="text"
+              value={submitterName}
+              placeholder="Your name"
+              maxLength={100}
+            />
+          </div>
+          <div>
+            <label
+              className="mb-1 block text-sm font-medium text-ink"
+              htmlFor="submitterEmail"
+            >
+              Your email
+            </label>
+            <input
+              className={inputClass}
+              id="submitterEmail"
+              onChange={(e) => setSubmitterEmail(e.target.value)}
+              type="email"
+              value={submitterEmail}
+              placeholder="your.email@example.com"
+            />
           </div>
         </div>
+      </div>
 
-        <div className="flex items-center justify-end gap-4 pt-2">
-          {onCancel && (
-            <button
-              className={clsx(
-                "inline-flex items-center rounded-md border border-transparent px-4 py-2 font-medium text-gray-700",
-                "hover:bg-gray-100",
-                "focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-hidden",
-              )}
-              onClick={onCancel}
-              type="button"
-            >
-              Cancel
-            </button>
-          )}
-          <PrimaryButton disabled={isSubmitting} type="submit">
-            {isSubmitting
-              ? "Submitting..."
-              : entries.length === 1
-                ? "Submit Birthday"
-                : `Submit ${entries.length} Birthdays`}
-          </PrimaryButton>
-        </div>
-      </form>
-    </div>
+      <div className="flex items-center justify-end gap-4 pt-2">
+        {onCancel && (
+          <button
+            className={clsx(
+              "inline-flex items-center rounded-md border border-rule bg-paper px-4 py-2 font-medium text-ink transition",
+              "hover:bg-paper-deep",
+              "focus:outline-hidden focus:ring-2 focus:ring-accent/40 focus:ring-offset-2",
+            )}
+            onClick={onCancel}
+            type="button"
+          >
+            Cancel
+          </button>
+        )}
+        <PrimaryButton disabled={isSubmitting} type="submit">
+          {isSubmitting
+            ? "Submitting…"
+            : entries.length === 1
+              ? "Submit birthday"
+              : `Submit ${entries.length} birthdays`}
+        </PrimaryButton>
+      </div>
+    </form>
   );
 };
 

--- a/components/SharingLinkManager.tsx
+++ b/components/SharingLinkManager.tsx
@@ -19,6 +19,7 @@ interface SharingLink {
   expiresAt: string;
   isActive: boolean;
   description?: string;
+  category?: string;
   submissionCount: number;
 }
 
@@ -26,6 +27,7 @@ const SharingLinkManager = () => {
   const [copiedLinkId, setCopiedLinkId] = useState<string | null>(null);
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [description, setDescription] = useState("");
+  const [category, setCategory] = useState("");
   const [expirationHours, setExpirationHours] = useState(168); // 7 days default
 
   const {
@@ -42,6 +44,7 @@ const SharingLinkManager = () => {
     {
       onCompleted: () => {
         setDescription("");
+        setCategory("");
         setExpirationHours(168);
         setShowCreateForm(false);
         refetchSharingLinks();
@@ -64,10 +67,12 @@ const SharingLinkManager = () => {
   const handleCreateLink = async (e: React.FormEvent) => {
     e.preventDefault();
     const trimmedDescription = description.trim() || undefined;
+    const trimmedCategory = category.trim() || undefined;
     try {
       await createSharingLink({
         variables: {
           description: trimmedDescription,
+          category: trimmedCategory,
           expirationHours,
         },
       });
@@ -119,15 +124,15 @@ const SharingLinkManager = () => {
 
     if (isExpiredLink) {
       return (
-        <span className="font-medium text-rose-700">
-          Expired {format(date, "MMMM d 'at' p")}
+        <span className="font-medium text-rose-800">
+          Expired {format(date, "MMM d 'at' p")}
         </span>
       );
     }
 
     return (
-      <span className="text-ink-soft">
-        Expires {format(date, "MMMM d 'at' p")}
+      <span className="text-ink">
+        Expires {format(date, "MMM d 'at' p")}
       </span>
     );
   };
@@ -177,9 +182,30 @@ const SharingLinkManager = () => {
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
                   placeholder="e.g. Family gathering, work colleagues"
-                  className="w-full rounded-md border border-rule bg-paper px-3 py-2 text-sm text-ink placeholder:text-ink-muted focus:border-accent focus:outline-hidden focus:ring-1 focus:ring-accent"
+                  className="w-full rounded-md border border-rule bg-paper px-3 py-2 text-sm text-ink placeholder:text-ink-soft focus:border-accent focus:outline-hidden focus:ring-1 focus:ring-accent"
                   maxLength={100}
                 />
+              </div>
+              <div>
+                <label
+                  htmlFor="category"
+                  className="mb-1 block text-sm font-medium text-ink"
+                >
+                  Category (optional)
+                </label>
+                <input
+                  type="text"
+                  id="category"
+                  value={category}
+                  onChange={(e) => setCategory(e.target.value)}
+                  placeholder="e.g. Family, Coworkers"
+                  className="w-full rounded-md border border-rule bg-paper px-3 py-2 text-sm text-ink placeholder:text-ink-soft focus:border-accent focus:outline-hidden focus:ring-1 focus:ring-accent"
+                  maxLength={50}
+                />
+                <p className="mt-1 text-xs text-ink-soft">
+                  Birthdays submitted through this link will be filed under this
+                  category.
+                </p>
               </div>
               <div>
                 <label
@@ -210,6 +236,7 @@ const SharingLinkManager = () => {
                   onClick={() => {
                     setShowCreateForm(false);
                     setDescription("");
+                    setCategory("");
                     setExpirationHours(168);
                   }}
                   className="rounded-md border border-rule bg-paper px-4 py-2 text-sm font-medium text-ink transition hover:bg-paper-deep"
@@ -235,95 +262,125 @@ const SharingLinkManager = () => {
           </div>
         ) : sharingLinks.length === 0 ? (
           <div className="py-8 text-center">
-            <IoShareOutline className="mx-auto mb-4 h-12 w-12 text-ink-muted" />
+            <IoShareOutline className="mx-auto mb-4 h-12 w-12 text-ink-soft" />
             <h3 className="mb-2 font-display text-lg font-semibold text-ink">
               No sharing links yet
             </h3>
-            <p className="mb-4 text-ink-soft">
+            <p className="mb-4 text-ink">
               Create a sharing link to let friends and family contribute
               birthdays to your collection.
             </p>
           </div>
         ) : (
-          <div className="space-y-4">
-            {sharingLinks.map((link) => (
-              <div
-                key={link.id}
-                className={clsx(
-                  "rounded-lg border p-4 transition-colors",
-                  isExpired(link.expiresAt)
-                    ? "border-rose-300 bg-rose-50"
-                    : "border-rule bg-paper hover:bg-paper-deep",
-                )}
-              >
-                <div className="flex items-start justify-between">
-                  <div className="min-w-0 flex-1">
-                    <div className="mb-2 flex items-center space-x-2">
-                      {link.description && (
-                        <h4 className="text-sm font-medium text-ink">
-                          {link.description}
-                        </h4>
+          <div className="overflow-x-auto rounded-lg border border-rule bg-paper">
+            <table className="w-full min-w-[960px] text-sm text-ink">
+              <thead className="border-b border-rule bg-paper-deep text-left text-xs font-semibold uppercase tracking-wide text-ink">
+                <tr>
+                  <th className="px-3 py-2.5">Label</th>
+                  <th className="px-3 py-2.5">Category</th>
+                  <th className="px-3 py-2.5">Link</th>
+                  <th className="px-3 py-2.5 text-center">Submissions</th>
+                  <th className="px-3 py-2.5">Created</th>
+                  <th className="px-3 py-2.5">Status</th>
+                  <th className="px-3 py-2.5 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-rule">
+                {sharingLinks.map((link) => {
+                  const expired = isExpired(link.expiresAt);
+                  const url = `${window.location.origin}/share/${link.token}`;
+                  return (
+                    <tr
+                      key={link.id}
+                      className={clsx(
+                        "transition-colors",
+                        expired ? "bg-rose-50" : "hover:bg-paper-deep",
                       )}
-                      <span className="inline-flex items-center rounded-full bg-paper-deep px-2 py-1 text-xs font-medium text-accent-deep">
-                        {link.submissionCount} submission
-                        {link.submissionCount !== 1 ? "s" : ""}
-                      </span>
-                    </div>
-                    <div className="mb-2 text-sm text-ink-soft">
-                      Created {format(new Date(link.createdAt), "MMM d, yyyy")}
-                    </div>
-                    <div className="mb-3 text-sm">
-                      {formatExpirationDate(link.expiresAt)}
-                    </div>
-                    {!isExpired(link.expiresAt) && (
-                      <div className="flex items-center space-x-2 rounded-md bg-paper-deep p-2">
-                        <code className="flex-1 text-sm break-all text-ink">
-                          {window.location.origin}/share/{link.token}
-                        </code>
-                      </div>
-                    )}
-                  </div>
-                  <div className="ml-4 flex items-center space-x-2">
-                    {!isExpired(link.expiresAt) && (
-                      <button
-                        onClick={() => copyToClipboard(link.token, link.id)}
-                        className={clsx(
-                          "flex items-center space-x-1 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                          copiedLinkId === link.id
-                            ? "bg-emerald-100 text-emerald-800"
-                            : "bg-paper-deep text-ink hover:bg-paper",
-                        )}
-                        title="Copy link to clipboard"
-                      >
-                        {copiedLinkId === link.id ? (
-                          <>
-                            <HiClipboardCheck className="h-4 w-4" />
-                            <span>Copied</span>
-                          </>
-                        ) : (
-                          <>
-                            <HiClipboard className="h-4 w-4" />
-                            <span>Copy</span>
-                          </>
-                        )}
-                      </button>
-                    )}
-                    <button
-                      onClick={() => handleRevokeLink(link.id)}
-                      className="flex items-center space-x-1 rounded-md bg-rose-100 px-3 py-2 text-sm font-medium text-rose-800 transition-colors hover:bg-rose-200"
-                      title="Revoke this link"
                     >
-                      <HiTrash className="h-4 w-4" />
-                      <span>Revoke</span>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            ))}
+                      <td className="px-3 py-3 align-top font-medium text-ink">
+                        {link.description || (
+                          <span className="text-ink-soft">—</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-3 align-top">
+                        {link.category ? (
+                          <span className="inline-flex rounded-full border border-rule bg-paper-deep px-2 py-0.5 text-xs text-ink">
+                            {link.category}
+                          </span>
+                        ) : (
+                          <span className="text-ink-soft">—</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-3 align-top">
+                        {expired ? (
+                          <span className="text-ink-soft italic">
+                            link no longer active
+                          </span>
+                        ) : (
+                          <code
+                            className="block max-w-[28rem] truncate font-mono text-xs text-ink"
+                            title={url}
+                          >
+                            {url}
+                          </code>
+                        )}
+                      </td>
+                      <td className="px-3 py-3 text-center align-top font-semibold text-ink tabular-nums">
+                        {link.submissionCount}
+                      </td>
+                      <td className="px-3 py-3 align-top whitespace-nowrap text-ink">
+                        {format(new Date(link.createdAt), "MMM d, yyyy")}
+                      </td>
+                      <td className="px-3 py-3 align-top whitespace-nowrap">
+                        {formatExpirationDate(link.expiresAt)}
+                      </td>
+                      <td className="px-3 py-3 align-top">
+                        <div className="flex items-center justify-end gap-2">
+                          {!expired && (
+                            <button
+                              onClick={() =>
+                                copyToClipboard(link.token, link.id)
+                              }
+                              className={clsx(
+                                "flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors",
+                                copiedLinkId === link.id
+                                  ? "bg-emerald-100 text-emerald-900"
+                                  : "bg-paper-deep text-ink hover:bg-rule",
+                              )}
+                              title="Copy link to clipboard"
+                            >
+                              {copiedLinkId === link.id ? (
+                                <>
+                                  <HiClipboardCheck className="h-4 w-4" />
+                                  <span>Copied</span>
+                                </>
+                              ) : (
+                                <>
+                                  <HiClipboard className="h-4 w-4" />
+                                  <span>Copy</span>
+                                </>
+                              )}
+                            </button>
+                          )}
+                          <button
+                            onClick={() => handleRevokeLink(link.id)}
+                            className="flex items-center gap-1 rounded-md bg-rose-100 px-2.5 py-1.5 text-xs font-medium text-rose-900 transition-colors hover:bg-rose-200"
+                            title="Revoke this link"
+                          >
+                            <HiTrash className="h-4 w-4" />
+                            <span>Revoke</span>
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
           </div>
         )}
 
-        <div className="mt-6 text-sm text-ink-soft">
+        <div className="mt-6 text-sm text-ink">
           <p>
             Share these links with friends and family to let them contribute
             birthdays to your collection. You can review and import their

--- a/components/SubmissionReviewInterface.tsx
+++ b/components/SubmissionReviewInterface.tsx
@@ -10,7 +10,7 @@ import LoadingSpinner from "./LoadingSpinner";
 import { useMutation, useQuery } from "@apollo/client/react";
 import clsx from "clsx";
 import { format } from "date-fns";
-import { useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   HiCheck,
   HiCheckCircle,
@@ -373,187 +373,243 @@ const SubmissionReviewInterface = () => {
               )}
             </div>
 
-            {/* Submissions List */}
-            <div className="space-y-4">
-              {submissionsWithDuplicates.map((submission) => {
-                const isExpanded = expandedSubmissions.has(submission.id);
-                const isSelected = selectedSubmissions.has(submission.id);
-                const isProcessing = processingSubmissions.has(submission.id);
-                const hasDuplicates = submission.duplicates.length > 0;
+            {/* Submissions Table */}
+            <div className="overflow-x-auto rounded-lg border border-rule bg-paper">
+              <table className="w-full min-w-[1024px] text-sm text-ink">
+                <thead className="border-b border-rule bg-paper-deep text-left text-xs font-semibold uppercase tracking-wide text-ink">
+                  <tr>
+                    <th className="w-10 px-3 py-2.5"></th>
+                    <th className="px-3 py-2.5">Name</th>
+                    <th className="px-3 py-2.5">Birthday</th>
+                    <th className="px-3 py-2.5">Category</th>
+                    <th className="px-3 py-2.5">Submitter</th>
+                    <th className="px-3 py-2.5">Source</th>
+                    <th className="px-3 py-2.5">Submitted</th>
+                    <th className="px-3 py-2.5 text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-rule">
+                  {submissionsWithDuplicates.map((submission) => {
+                    const isExpanded = expandedSubmissions.has(submission.id);
+                    const isSelected = selectedSubmissions.has(submission.id);
+                    const isProcessing = processingSubmissions.has(
+                      submission.id,
+                    );
+                    const hasDuplicates = submission.duplicates.length > 0;
+                    const hasDetails = Boolean(
+                      submission.notes || submission.submitterEmail,
+                    );
+                    const showExpandedRow = isExpanded && hasDetails;
+                    const expandable = hasDetails || hasDuplicates;
 
-                return (
-                  <div
-                    key={submission.id}
-                    className={clsx(
-                      "rounded-lg border p-4 transition-colors",
-                      hasDuplicates
-                        ? "border-amber-300 bg-amber-50"
-                        : isSelected
-                          ? "border-accent bg-paper"
-                          : "border-rule bg-paper hover:bg-paper-deep",
-                    )}
-                  >
-                    <div className="flex items-start justify-between">
-                      <div className="flex items-start space-x-3">
-                        <input
-                          type="checkbox"
-                          checked={isSelected}
-                          onChange={() =>
-                            toggleSubmissionSelection(submission.id)
-                          }
-                          className="mt-1 h-4 w-4 rounded border-rule text-accent focus:ring-accent/40"
-                        />
-                        <div className="min-w-0 flex-1">
-                          <div className="flex items-center space-x-2">
-                            <h4 className="text-lg font-medium text-ink">
-                              {submission.name}
-                            </h4>
-                            {hasDuplicates && (
-                              <HiExclamationCircle className="h-5 w-5 text-amber-600" />
-                            )}
-                          </div>
-                          <div className="mt-1 flex items-center space-x-4 text-sm text-ink-soft">
-                            <div className="flex items-center space-x-1">
-                              <IoCalendarOutline className="h-4 w-4" />
+                    return (
+                      <React.Fragment key={submission.id}>
+                        <tr
+                          className={clsx(
+                            "transition-colors",
+                            hasDuplicates
+                              ? "bg-amber-50 hover:bg-amber-100"
+                              : isSelected
+                                ? "bg-paper-deep"
+                                : "hover:bg-paper-deep",
+                          )}
+                        >
+                          <td className="px-3 py-3 align-top">
+                            <input
+                              type="checkbox"
+                              checked={isSelected}
+                              onChange={() =>
+                                toggleSubmissionSelection(submission.id)
+                              }
+                              aria-label={`Select submission for ${submission.name}`}
+                              className="h-4 w-4 rounded border-rule text-accent focus:ring-accent/40"
+                            />
+                          </td>
+                          <td className="px-3 py-3 align-top">
+                            <div className="flex items-start gap-1.5">
+                              <span className="font-medium text-ink">
+                                {submission.name}
+                              </span>
+                              {hasDuplicates && (
+                                <HiExclamationCircle
+                                  className="mt-0.5 h-4 w-4 shrink-0 text-amber-700"
+                                  title={`${submission.duplicates.length} potential duplicate(s)`}
+                                />
+                              )}
+                            </div>
+                          </td>
+                          <td className="px-3 py-3 align-top whitespace-nowrap text-ink">
+                            <div className="flex items-center gap-1.5">
+                              <IoCalendarOutline className="h-4 w-4 text-ink-soft" />
                               <span>{formatSubmissionDate(submission)}</span>
                             </div>
-                            {submission.category && (
-                              <span className="rounded-full border border-rule bg-paper px-2 py-1 text-xs text-ink">
+                          </td>
+                          <td className="px-3 py-3 align-top">
+                            {submission.category ? (
+                              <span className="inline-flex rounded-full border border-rule bg-paper px-2 py-0.5 text-xs text-ink">
                                 {submission.category}
                               </span>
+                            ) : (
+                              <span className="text-ink-soft">—</span>
                             )}
-                          </div>
-                          {submission.submitterName && (
-                            <div className="mt-1 text-sm text-ink-soft">
-                              Submitted by {submission.submitterName}
-                              {submission.relationship &&
-                                ` (${submission.relationship})`}
-                            </div>
-                          )}
-                          {submission.sharingLink.description && (
-                            <div className="mt-1 text-sm text-ink-soft">
-                              via &quot;{submission.sharingLink.description}
-                              &quot;
-                            </div>
-                          )}
-                          <div className="mt-1 text-xs text-ink-muted">
+                          </td>
+                          <td className="px-3 py-3 align-top text-ink">
+                            {submission.submitterName ? (
+                              <>
+                                <div>{submission.submitterName}</div>
+                                {submission.relationship && (
+                                  <div className="text-xs text-ink-soft">
+                                    {submission.relationship}
+                                  </div>
+                                )}
+                              </>
+                            ) : (
+                              <span className="text-ink-soft">Anonymous</span>
+                            )}
+                          </td>
+                          <td className="px-3 py-3 align-top text-ink">
+                            {submission.sharingLink.description || (
+                              <span className="text-ink-soft">—</span>
+                            )}
+                          </td>
+                          <td className="px-3 py-3 align-top whitespace-nowrap text-ink">
                             {format(
                               new Date(submission.createdAt),
-                              "MMM d, yyyy 'at' h:mm a",
+                              "MMM d, h:mm a",
                             )}
-                          </div>
-
-                          {/* Duplicate Warning */}
-                          {hasDuplicates && (
-                            <div className="mt-2 rounded-md border border-amber-200 bg-amber-50 p-3">
-                              <div className="flex items-start space-x-2">
-                                <HiExclamationCircle className="mt-0.5 h-4 w-4 text-amber-700" />
-                                <div className="text-sm">
-                                  <p className="font-medium text-amber-900">
-                                    Potential duplicate detected
-                                  </p>
-                                  <p className="mt-1 text-amber-800">
-                                    Similar birthdays already exist in your
-                                    list:
-                                  </p>
-                                  <ul className="mt-2 space-y-1">
-                                    {submission.duplicates.map((duplicate) => (
-                                      <li
-                                        key={duplicate.id}
-                                        className="text-amber-800"
-                                      >
-                                        • {duplicate.name},{" "}
-                                        {formatSubmissionDate(duplicate)}
-                                        {duplicate.category &&
-                                          ` (${duplicate.category})`}
-                                      </li>
-                                    ))}
-                                  </ul>
-                                </div>
-                              </div>
-                            </div>
-                          )}
-
-                          {/* Expanded Details */}
-                          {isExpanded && (
-                            <div className="mt-3 space-y-2 rounded-md bg-paper-deep p-3">
-                              {submission.notes && (
-                                <div>
-                                  <span className="text-sm font-medium text-ink">
-                                    Notes:
-                                  </span>
-                                  <p className="mt-1 text-sm text-ink-soft">
-                                    {submission.notes}
-                                  </p>
-                                </div>
+                          </td>
+                          <td className="px-3 py-3 align-top">
+                            <div className="flex items-center justify-end gap-1.5">
+                              {expandable && (
+                                <button
+                                  onClick={() =>
+                                    toggleSubmissionExpansion(submission.id)
+                                  }
+                                  className={clsx(
+                                    "rounded-md border border-rule bg-paper p-1.5 text-ink-soft transition hover:bg-paper-deep hover:text-ink",
+                                    isExpanded && "bg-paper-deep text-ink",
+                                  )}
+                                  title={isExpanded ? "Hide details" : "Show details"}
+                                  aria-expanded={isExpanded}
+                                >
+                                  <HiInformationCircle className="h-4 w-4" />
+                                </button>
                               )}
-                              {submission.submitterEmail && (
-                                <div>
-                                  <span className="text-sm font-medium text-ink">
-                                    Email:
-                                  </span>
-                                  <p className="mt-1 text-sm text-ink-soft">
-                                    {submission.submitterEmail}
-                                  </p>
-                                </div>
-                              )}
+                              <button
+                                onClick={() =>
+                                  handleImportSubmission(submission.id)
+                                }
+                                disabled={isProcessing}
+                                className={clsx(
+                                  "flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors",
+                                  isProcessing
+                                    ? "bg-paper-deep text-ink-soft"
+                                    : "bg-emerald-100 text-emerald-900 hover:bg-emerald-200",
+                                )}
+                              >
+                                {isProcessing ? (
+                                  <LoadingSpinner size="sm" />
+                                ) : (
+                                  <HiCheck className="h-4 w-4" />
+                                )}
+                                <span>Import</span>
+                              </button>
+                              <button
+                                onClick={() =>
+                                  handleRejectSubmission(submission.id)
+                                }
+                                disabled={isProcessing}
+                                className={clsx(
+                                  "flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors",
+                                  isProcessing
+                                    ? "bg-paper-deep text-ink-soft"
+                                    : "bg-rose-100 text-rose-900 hover:bg-rose-200",
+                                )}
+                              >
+                                {isProcessing ? (
+                                  <LoadingSpinner size="sm" />
+                                ) : (
+                                  <HiX className="h-4 w-4" />
+                                )}
+                                <span>Reject</span>
+                              </button>
                             </div>
-                          )}
-                        </div>
-                      </div>
-
-                      {/* Action Buttons */}
-                      <div className="flex items-center space-x-2">
-                        {(submission.notes || submission.submitterEmail) && (
-                          <button
-                            onClick={() =>
-                              toggleSubmissionExpansion(submission.id)
-                            }
-                            className="rounded-md border border-rule bg-paper p-2 text-ink-soft transition hover:bg-paper-deep hover:text-ink"
-                            title={isExpanded ? "Show less" : "Show more"}
+                          </td>
+                        </tr>
+                        {(hasDuplicates || showExpandedRow) && (
+                          <tr
+                            className={clsx(
+                              hasDuplicates ? "bg-amber-50" : "bg-paper-deep",
+                            )}
                           >
-                            <HiInformationCircle className="h-4 w-4" />
-                          </button>
+                            <td></td>
+                            <td colSpan={7} className="px-3 pb-3 pt-0">
+                              <div className="space-y-2">
+                                {hasDuplicates && (
+                                  <div className="rounded-md border border-amber-200 bg-amber-100/60 p-3">
+                                    <div className="flex items-start gap-2">
+                                      <HiExclamationCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-800" />
+                                      <div className="text-sm">
+                                        <p className="font-medium text-amber-900">
+                                          Potential duplicate detected
+                                        </p>
+                                        <ul className="mt-1 space-y-0.5">
+                                          {submission.duplicates.map(
+                                            (duplicate) => (
+                                              <li
+                                                key={duplicate.id}
+                                                className="text-amber-900"
+                                              >
+                                                • {duplicate.name},{" "}
+                                                {formatSubmissionDate(duplicate)}
+                                                {duplicate.category &&
+                                                  ` (${duplicate.category})`}
+                                              </li>
+                                            ),
+                                          )}
+                                        </ul>
+                                      </div>
+                                    </div>
+                                  </div>
+                                )}
+                                {showExpandedRow && (
+                                  <div className="rounded-md border border-rule bg-paper p-3">
+                                    {submission.notes && (
+                                      <div className="mb-2 last:mb-0">
+                                        <span className="text-xs font-semibold uppercase tracking-wide text-ink-soft">
+                                          Notes
+                                        </span>
+                                        <p className="mt-0.5 text-sm text-ink">
+                                          {submission.notes}
+                                        </p>
+                                      </div>
+                                    )}
+                                    {submission.submitterEmail && (
+                                      <div>
+                                        <span className="text-xs font-semibold uppercase tracking-wide text-ink-soft">
+                                          Email
+                                        </span>
+                                        <p className="mt-0.5 text-sm text-ink">
+                                          <a
+                                            href={`mailto:${submission.submitterEmail}`}
+                                            className="text-accent-deep underline underline-offset-4 hover:text-accent"
+                                          >
+                                            {submission.submitterEmail}
+                                          </a>
+                                        </p>
+                                      </div>
+                                    )}
+                                  </div>
+                                )}
+                              </div>
+                            </td>
+                          </tr>
                         )}
-                        <button
-                          onClick={() => handleImportSubmission(submission.id)}
-                          disabled={isProcessing}
-                          className={clsx(
-                            "flex items-center space-x-1 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                            isProcessing
-                              ? "bg-paper-deep text-ink-muted"
-                              : "bg-emerald-100 text-emerald-800 hover:bg-emerald-200",
-                          )}
-                        >
-                          {isProcessing ? (
-                            <LoadingSpinner size="sm" />
-                          ) : (
-                            <HiCheck className="h-4 w-4" />
-                          )}
-                          <span>Import</span>
-                        </button>
-                        <button
-                          onClick={() => handleRejectSubmission(submission.id)}
-                          disabled={isProcessing}
-                          className={clsx(
-                            "flex items-center space-x-1 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                            isProcessing
-                              ? "bg-paper-deep text-ink-muted"
-                              : "bg-rose-100 text-rose-800 hover:bg-rose-200",
-                          )}
-                        >
-                          {isProcessing ? (
-                            <LoadingSpinner size="sm" />
-                          ) : (
-                            <HiX className="h-4 w-4" />
-                          )}
-                          <span>Reject</span>
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                );
-              })}
+                      </React.Fragment>
+                    );
+                  })}
+                </tbody>
+              </table>
             </div>
           </>
         )}

--- a/components/layout/PublicLayout.tsx
+++ b/components/layout/PublicLayout.tsx
@@ -15,7 +15,7 @@ const PublicLayout = ({
   const router = useRouter();
 
   return (
-    <div className="flex min-h-screen flex-col justify-between">
+    <div className="flex min-h-screen flex-col justify-between bg-paper text-ink">
       <Head>
         {/* General */}
         <title>{title}</title>
@@ -75,7 +75,7 @@ const PublicLayout = ({
               alt="Lazy Uncle"
               height={47}
               priority
-              src="/lazy-uncle-white.svg"
+              src="/lazy-uncle.svg"
               width={160}
             />
           </Link>
@@ -84,11 +84,14 @@ const PublicLayout = ({
 
       <main className="flex-1 px-4 py-8 md:px-8">{children}</main>
 
-      <footer className="px-4 py-6 text-center text-gray-200 md:flex md:justify-between md:px-8">
+      <footer className="px-4 py-6 text-center text-ink-soft md:flex md:justify-between md:px-8">
         <div>
           &copy; 2020-{new Date().getFullYear()}
           {` `}
-          <a className="underline" href="https://michaelbonner.dev">
+          <a
+            className="underline underline-offset-4 hover:text-ink"
+            href="https://michaelbonner.dev"
+          >
             Michael Bonner
           </a>
         </div>

--- a/drizzle/migrations/0003_neat_hitman.sql
+++ b/drizzle/migrations/0003_neat_hitman.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "SharingLink" ADD COLUMN "category" text;

--- a/drizzle/migrations/meta/0003_snapshot.json
+++ b/drizzle/migrations/meta/0003_snapshot.json
@@ -1,0 +1,815 @@
+{
+  "id": "0820b88b-9ab2-4b71-bb80-fb13712673cb",
+  "prevId": "d9589ca9-520f-45d8-916c-5e7ccaf2c47d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_secret": {
+          "name": "oauth_token_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token": {
+          "name": "oauth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.BirthdaySubmission": {
+      "name": "BirthdaySubmission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sharingLinkId": {
+          "name": "sharingLinkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitterName": {
+          "name": "submitterName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitterEmail": {
+          "name": "submitterEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "SubmissionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "BirthdaySubmission_sharingLinkId_idx": {
+          "name": "BirthdaySubmission_sharingLinkId_idx",
+          "columns": [
+            {
+              "expression": "sharingLinkId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "BirthdaySubmission_status_idx": {
+          "name": "BirthdaySubmission_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Birthday": {
+      "name": "Birthday",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent": {
+          "name": "parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remindersEnabled": {
+          "name": "remindersEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importSource": {
+          "name": "importSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Birthday_userId_idx": {
+          "name": "Birthday_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Birthday_month_day_idx": {
+          "name": "Birthday_month_day_idx",
+          "columns": [
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.NotificationPreference": {
+      "name": "NotificationPreference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailNotifications": {
+          "name": "emailNotifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "summaryNotifications": {
+          "name": "summaryNotifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "birthdayReminders": {
+          "name": "birthdayReminders",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "NotificationPreference_userId_unique": {
+          "name": "NotificationPreference_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SharingLink": {
+      "name": "SharingLink",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "SharingLink_userId_idx": {
+          "name": "SharingLink_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SharingLink_token_idx": {
+          "name": "SharingLink_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "SharingLink_token_unique": {
+          "name": "SharingLink_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.VerificationToken": {
+      "name": "VerificationToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "VerificationToken_token_unique": {
+          "name": "VerificationToken_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        },
+        "VerificationToken_identifier_token_unique": {
+          "name": "VerificationToken_identifier_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.SubmissionStatus": {
+      "name": "SubmissionStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "IMPORTED",
+        "REJECTED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1771467734006,
       "tag": "0002_breezy_ser_duncan",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1779501473628,
+      "tag": "0003_neat_hitman",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -120,6 +120,7 @@ export const sharingLinks = pgTable(
     expiresAt: timestamp("expiresAt").notNull(),
     isActive: boolean("isActive").default(true).notNull(),
     description: text("description"),
+    category: text("category"),
   },
   (table) => [
     unique().on(table.token),

--- a/generated/nexus-typegen.ts
+++ b/generated/nexus-typegen.ts
@@ -109,6 +109,7 @@ export interface NexusGenObjects {
   }
   Query: {};
   SharingLink: { // root type
+    category?: string | null; // String
     createdAt?: NexusGenScalars['DateTime'] | null; // DateTime
     description?: string | null; // String
     expiresAt?: NexusGenScalars['DateTime'] | null; // DateTime
@@ -239,6 +240,7 @@ export interface NexusGenFieldTypes {
     validateSharingLink: NexusGenRootTypes['SharingLinkValidation'] | null; // SharingLinkValidation
   }
   SharingLink: { // field return type
+    category: string | null; // String
     createdAt: NexusGenScalars['DateTime'] | null; // DateTime
     description: string | null; // String
     expiresAt: NexusGenScalars['DateTime'] | null; // DateTime
@@ -362,6 +364,7 @@ export interface NexusGenFieldTypeNames {
     validateSharingLink: 'SharingLinkValidation'
   }
   SharingLink: { // field return type name
+    category: 'String'
     createdAt: 'DateTime'
     description: 'String'
     expiresAt: 'DateTime'
@@ -413,6 +416,7 @@ export interface NexusGenArgTypes {
       year?: number | null; // Int
     }
     createSharingLink: { // args
+      category?: string | null; // String
       description?: string | null; // String
       expirationHours?: number | null; // Int
     }
@@ -444,7 +448,6 @@ export interface NexusGenArgTypes {
       linkId: string; // String!
     }
     submitBirthday: { // args
-      category?: string | null; // String
       day: number; // Int!
       month: number; // Int!
       name: string; // String!

--- a/generated/schema.graphql
+++ b/generated/schema.graphql
@@ -68,14 +68,14 @@ type Mutation {
   bulkImportSubmissions(submissionIds: [String!]!): BulkSubmissionResult
   bulkRejectSubmissions(submissionIds: [String!]!): BulkSubmissionResult
   createBirthday(category: String, day: Int!, importSource: String, month: Int!, name: String!, notes: String, parent: String, remindersEnabled: Boolean, userId: String!, year: Int): Birthday
-  createSharingLink(description: String, expirationHours: Int): SharingLink
+  createSharingLink(category: String, description: String, expirationHours: Int): SharingLink
   deleteBirthday(birthdayId: String!): Birthday
   editBirthday(category: String, day: Int!, id: String!, importSource: String, month: Int!, name: String!, notes: String, parent: String, remindersEnabled: Boolean, year: Int): Birthday
   getSubmissionDuplicates(submissionId: String!): DuplicateDetectionResult
   importSubmission(submissionId: String!): Birthday
   rejectSubmission(submissionId: String!): BirthdaySubmission
   revokeSharingLink(linkId: String!): SharingLink
-  submitBirthday(category: String, day: Int!, month: Int!, name: String!, notes: String, relationship: String, submitterEmail: String, submitterName: String, token: String!, year: Int): BirthdaySubmission
+  submitBirthday(day: Int!, month: Int!, name: String!, notes: String, relationship: String, submitterEmail: String, submitterName: String, token: String!, year: Int): BirthdaySubmission
   updateNotificationPreferences(birthdayReminders: Boolean, emailNotifications: Boolean, summaryNotifications: Boolean): NotificationPreference
 }
 
@@ -108,6 +108,7 @@ type Query {
 }
 
 type SharingLink {
+  category: String
   createdAt: DateTime
   description: String
   expiresAt: DateTime

--- a/graphql/Sharing.ts
+++ b/graphql/Sharing.ts
@@ -1,9 +1,14 @@
 import { gql } from "@apollo/client";
 
 export const CREATE_SHARING_LINK_MUTATION = gql`
-  mutation CreateSharingLink($description: String, $expirationHours: Int) {
+  mutation CreateSharingLink(
+    $description: String
+    $category: String
+    $expirationHours: Int
+  ) {
     createSharingLink(
       description: $description
+      category: $category
       expirationHours: $expirationHours
     ) {
       id
@@ -12,6 +17,7 @@ export const CREATE_SHARING_LINK_MUTATION = gql`
       expiresAt
       isActive
       description
+      category
       submissionCount
       __typename
     }
@@ -36,7 +42,6 @@ export const SUBMIT_BIRTHDAY_MUTATION = gql`
     $year: Int
     $month: Int!
     $day: Int!
-    $category: String
     $notes: String
     $submitterName: String
     $submitterEmail: String
@@ -48,7 +53,6 @@ export const SUBMIT_BIRTHDAY_MUTATION = gql`
       year: $year
       month: $month
       day: $day
-      category: $category
       notes: $notes
       submitterName: $submitterName
       submitterEmail: $submitterEmail
@@ -81,6 +85,7 @@ export const GET_SHARING_LINKS_QUERY = gql`
       expiresAt
       isActive
       description
+      category
       submissionCount
       __typename
     }

--- a/graphql/schema/Mutation.test.ts
+++ b/graphql/schema/Mutation.test.ts
@@ -899,8 +899,8 @@ describe("Submission Management GraphQL Operations", () => {
         {
           ...mockSubmission,
           sharingLink: {
-            id: "link-1",
             description: null,
+            createdAt: new Date(),
           },
         },
       ]);
@@ -971,8 +971,8 @@ describe("Submission Management GraphQL Operations", () => {
         {
           ...mockSubmission,
           sharingLink: {
-            id: "link-1",
             description: null,
+            createdAt: new Date(),
           },
         },
       ]);

--- a/graphql/schema/Mutation.ts
+++ b/graphql/schema/Mutation.ts
@@ -199,9 +199,10 @@ export const Mutation = extendType({
       type: "SharingLink",
       args: {
         description: stringArg(),
+        category: stringArg(),
         expirationHours: intArg(),
       },
-      resolve: async (_, { description, expirationHours }, ctx) => {
+      resolve: async (_, { description, category, expirationHours }, ctx) => {
         const { SharingService } = await import("../../lib/sharing-service");
         const { SecurityMiddleware } =
           await import("../../lib/security-middleware");
@@ -232,6 +233,7 @@ export const Mutation = extendType({
           userId: ctx.user.id,
           expirationHours: expirationHours || undefined,
           description: description || undefined,
+          category: category || undefined,
         });
       },
     });
@@ -264,7 +266,6 @@ export const Mutation = extendType({
         year: intArg(),
         month: nonNull(intArg()),
         day: nonNull(intArg()),
-        category: stringArg(),
         notes: stringArg(),
         submitterName: stringArg(),
         submitterEmail: stringArg(),
@@ -310,7 +311,6 @@ export const Mutation = extendType({
           year: args.year ?? null,
           month: args.month,
           day: args.day,
-          category: args.category || undefined,
           notes: args.notes || undefined,
           submitterName: args.submitterName || undefined,
           submitterEmail: args.submitterEmail || undefined,
@@ -505,7 +505,6 @@ export const Mutation = extendType({
           year: submission.year ?? null,
           month: submission.month,
           day: submission.day,
-          category: submission.category || undefined,
           notes: submission.notes || undefined,
           submitterName: submission.submitterName || undefined,
           submitterEmail: submission.submitterEmail || undefined,

--- a/graphql/schema/Sharing.ts
+++ b/graphql/schema/Sharing.ts
@@ -24,6 +24,7 @@ export const SharingLink = objectType({
     });
     t.boolean("isActive");
     t.nullable.string("description");
+    t.nullable.string("category");
     t.int("submissionCount", {
       resolve: async (parent, args, ctx) => {
         if (!parent.id) {

--- a/lib/birthday-submission.test.ts
+++ b/lib/birthday-submission.test.ts
@@ -192,6 +192,7 @@ describe("Birthday Submission API", () => {
         expiresAt: new Date(Date.now() + 1000000),
         isActive: true,
         description: null,
+        category: null,
       });
       mockDb.query.birthdaySubmissions.findMany.mockResolvedValue([
         {
@@ -235,6 +236,7 @@ describe("Birthday Submission API", () => {
         expiresAt: new Date(Date.now() + 1000000),
         isActive: true,
         description: null,
+        category: null,
       });
       mockDb.query.birthdaySubmissions.findMany
         .mockResolvedValueOnce([]) // No duplicates
@@ -264,12 +266,13 @@ describe("Birthday Submission API", () => {
         userId: "user-1",
         createdAt: new Date(),
         description: null,
+        category: null,
       };
 
       mockDb.query.sharingLinks.findFirst.mockResolvedValue({
         ...mockLink,
         user: { id: "user-1" },
-      });
+      } as never);
 
       const result = await SharingService.validateSharingLink("valid-token");
 
@@ -288,6 +291,7 @@ describe("Birthday Submission API", () => {
         userId: "user-1",
         createdAt: new Date(),
         description: null,
+        category: null,
       };
 
       mockDb.query.sharingLinks.findFirst.mockResolvedValue({
@@ -311,6 +315,7 @@ describe("Birthday Submission API", () => {
         userId: "user-1",
         createdAt: new Date(),
         description: null,
+        category: null,
       };
 
       mockDb.query.sharingLinks.findFirst.mockResolvedValue({
@@ -341,6 +346,7 @@ describe("Birthday Submission API", () => {
         userId: "user-1",
         createdAt: new Date(),
         description: null,
+        category: null,
       };
 
       const mockSubmission = {
@@ -378,6 +384,7 @@ describe("Birthday Submission API", () => {
         userId: "user-1",
         createdAt: new Date(),
         description: null,
+        category: null,
       };
 
       mockDb.query.sharingLinks.findFirst.mockResolvedValue({

--- a/lib/rate-limiter.integration.test.ts
+++ b/lib/rate-limiter.integration.test.ts
@@ -162,6 +162,7 @@ describe("RateLimitService Integration", () => {
         expiresAt: new Date(Date.now() + 1000000),
         isActive: true,
         description: null,
+        category: null,
       });
       mockDb.query.birthdaySubmissions.findMany.mockResolvedValueOnce([
         {
@@ -194,6 +195,7 @@ describe("RateLimitService Integration", () => {
         expiresAt: new Date(Date.now() + 1000000),
         isActive: true,
         description: null,
+        category: null,
       });
       mockDb.query.birthdaySubmissions.findMany
         .mockResolvedValueOnce([]) // duplicate count (no duplicates)
@@ -225,6 +227,7 @@ describe("RateLimitService Integration", () => {
         expiresAt: new Date(Date.now() + 1000000),
         isActive: true,
         description: null,
+        category: null,
       });
       mockDb.query.birthdaySubmissions.findMany
         .mockResolvedValueOnce([]) // duplicate count (no duplicates)
@@ -254,6 +257,7 @@ describe("RateLimitService Integration", () => {
         expiresAt: new Date(Date.now() + 1000000),
         isActive: true,
         description: null,
+        category: null,
       });
       mockDb.query.birthdaySubmissions.findMany.mockResolvedValueOnce([]); // duplicate count only
 
@@ -362,6 +366,7 @@ describe("RateLimitService Integration", () => {
         expiresAt: new Date(Date.now() + 1000000),
         isActive: true,
         description: null,
+        category: null,
       });
       mockDb.query.birthdaySubmissions.findMany.mockRejectedValue(
         new Error("Query timeout"),

--- a/lib/security-middleware.test.ts
+++ b/lib/security-middleware.test.ts
@@ -125,7 +125,7 @@ describe("SecurityMiddleware", () => {
         dailyLinksCount: 1,
       });
 
-      mockDb.query.sharingLinks.findMany.mockResolvedValue([{ id: "link" }]);
+      mockDb.query.sharingLinks.findMany.mockResolvedValue([{ id: "link" }] as never);
 
       const result =
         await SecurityMiddleware.checkSharingLinkRateLimit(mockContext);
@@ -582,7 +582,7 @@ describe("SecurityMiddleware", () => {
         dailyLinksCount: 1,
       });
 
-      mockDb.query.sharingLinks.findMany.mockResolvedValue([{ id: "link" }]);
+      mockDb.query.sharingLinks.findMany.mockResolvedValue([{ id: "link" }] as never);
 
       // Mock console.log to throw an error
       vi.mocked(console.log).mockImplementation(() => {

--- a/lib/sharing-service.test.ts
+++ b/lib/sharing-service.test.ts
@@ -68,6 +68,7 @@ describe("SharingService", () => {
         token: "mock-token",
         userId: mockUserId,
         description: "Test sharing link",
+        category: null,
         createdAt: new Date(),
         expiresAt: new Date(Date.now() + 168 * 60 * 60 * 1000), // 7 days
         isActive: true,
@@ -83,6 +84,7 @@ describe("SharingService", () => {
           token: expect.any(String),
           userId: mockUserId,
           description: "Test sharing link",
+          category: null,
           expiresAt: expect.any(Date),
           isActive: true,
         }),
@@ -102,6 +104,7 @@ describe("SharingService", () => {
         token: "mock-token",
         userId: mockUserId,
         description: "Test sharing link",
+        category: null,
         createdAt: new Date(),
         expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
         isActive: true,
@@ -216,6 +219,7 @@ describe("SharingService", () => {
         userId: "user-123",
         createdAt: new Date(),
         description: null,
+        category: null,
       };
       mockDb.query.sharingLinks.findFirst.mockResolvedValueOnce(mockLink);
 
@@ -234,6 +238,7 @@ describe("SharingService", () => {
         userId: "user-123",
         createdAt: new Date(),
         description: null,
+        category: null,
       };
       mockDb.query.sharingLinks.findFirst.mockResolvedValueOnce(mockLink);
       mockUpdate().set().where.mockResolvedValueOnce([mockLink]);
@@ -255,6 +260,7 @@ describe("SharingService", () => {
         userId: "user-123",
         createdAt: new Date(),
         description: null,
+        category: null,
       };
       mockDb.query.sharingLinks.findFirst.mockResolvedValueOnce(mockLink);
 
@@ -275,6 +281,7 @@ describe("SharingService", () => {
           expiresAt: new Date(),
           isActive: true,
           description: "Link 1",
+          category: null,
           submissions: Array(5).fill({ id: "sub" }),
         },
         {
@@ -285,6 +292,7 @@ describe("SharingService", () => {
           expiresAt: new Date(),
           isActive: false,
           description: "Link 2",
+          category: null,
           submissions: Array(2).fill({ id: "sub" }),
         },
       ];
@@ -310,6 +318,7 @@ describe("SharingService", () => {
           expiresAt: new Date(Date.now() + 1000000),
           isActive: true,
           description: "Active Link",
+          category: null,
           submissions: Array(3).fill({ id: "sub" }),
         },
       ];
@@ -333,6 +342,7 @@ describe("SharingService", () => {
         createdAt: new Date(),
         expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
         description: null,
+        category: null,
       };
 
       mockDb.query.sharingLinks.findFirst.mockResolvedValueOnce(mockLink);
@@ -396,6 +406,7 @@ describe("SharingService", () => {
         expiresAt: new Date(),
         isActive: true,
         description: null,
+        category: null,
       };
       mockDb.query.sharingLinks.findFirst.mockResolvedValueOnce(mockLink);
 
@@ -481,6 +492,7 @@ describe("SharingService", () => {
         expiresAt: new Date(),
         isActive: true,
         description: null,
+        category: null,
       };
       // Set up the mock chain before calling
       const mockReturning = vi.fn().mockResolvedValueOnce([mockSharingLink]);

--- a/lib/sharing-service.ts
+++ b/lib/sharing-service.ts
@@ -8,6 +8,7 @@ import { and, desc, eq, gt, gte, lt, lte } from "drizzle-orm";
 export interface CreateSharingLinkOptions {
   userId: string;
   description?: string;
+  category?: string;
   expirationHours?: number;
 }
 
@@ -37,6 +38,7 @@ export class SharingService {
     const {
       userId,
       description,
+      category,
       expirationHours = this.DEFAULT_EXPIRATION_HOURS,
     } = options;
 
@@ -110,6 +112,7 @@ export class SharingService {
         token,
         userId,
         description: description || null,
+        category: category || null,
         expiresAt,
         isActive: true,
       })

--- a/lib/submission-service.test.ts
+++ b/lib/submission-service.test.ts
@@ -110,11 +110,12 @@ describe("SubmissionService", () => {
       expiresAt: new Date(Date.now() + 86400000),
       isActive: true,
       description: "Test link",
+      category: "Friend",
     };
 
     it("should successfully process a valid submission", async () => {
       // Mock sharing link validation
-      mockSharingService.validateSharingLink.mockResolvedValue(mockSharingLink);
+      mockSharingService.validateSharingLink.mockResolvedValue(mockSharingLink as never);
 
       // Mock input validation
       mockInputValidator.validateBirthdaySubmission.mockReturnValue({
@@ -192,7 +193,7 @@ describe("SubmissionService", () => {
     });
 
     it("should reject submission with invalid input data", async () => {
-      mockSharingService.validateSharingLink.mockResolvedValue(mockSharingLink);
+      mockSharingService.validateSharingLink.mockResolvedValue(mockSharingLink as never);
 
       mockInputValidator.validateBirthdaySubmission.mockReturnValue({
         isValid: false,
@@ -212,7 +213,7 @@ describe("SubmissionService", () => {
     });
 
     it("should reject submission when rate limit exceeded", async () => {
-      mockSharingService.validateSharingLink.mockResolvedValue(mockSharingLink);
+      mockSharingService.validateSharingLink.mockResolvedValue(mockSharingLink as never);
 
       mockInputValidator.validateBirthdaySubmission.mockReturnValue({
         isValid: true,
@@ -240,7 +241,7 @@ describe("SubmissionService", () => {
     });
 
     it("should handle database errors gracefully", async () => {
-      mockSharingService.validateSharingLink.mockResolvedValue(mockSharingLink);
+      mockSharingService.validateSharingLink.mockResolvedValue(mockSharingLink as never);
 
       mockInputValidator.validateBirthdaySubmission.mockReturnValue({
         isValid: true,
@@ -555,6 +556,7 @@ describe("SubmissionService", () => {
           createdAt: new Date(),
           sharingLink: {
             description: "Family link",
+            category: null,
             createdAt: new Date(),
           },
           sharingLinkId: "link-123",
@@ -572,6 +574,7 @@ describe("SubmissionService", () => {
           createdAt: new Date(),
           sharingLink: {
             description: "Friends link",
+            category: null,
             createdAt: new Date(),
           },
           sharingLinkId: "link-123",

--- a/lib/submission-service.ts
+++ b/lib/submission-service.ts
@@ -42,7 +42,6 @@ export interface ProcessedSubmissionData {
   month: number;
   day: number;
   date?: string; // Deprecated: for backward compatibility
-  category?: string;
   notes?: string;
   submitterName?: string;
   submitterEmail?: string;
@@ -99,7 +98,8 @@ export class SubmissionService {
         validation.sanitizedData as BirthdaySubmissionInput,
       );
 
-      // Store the submission
+      // Store the submission. Category is inherited from the sharing link
+      // itself — submitters no longer choose it.
       const [submission] = await db
         .insert(birthdaySubmissions)
         .values({
@@ -109,7 +109,7 @@ export class SubmissionService {
           year: processedData.year,
           month: processedData.month,
           day: processedData.day,
-          category: processedData.category || null,
+          category: sharingLink.category || null,
           notes: processedData.notes || null,
           submitterName: processedData.submitterName || null,
           submitterEmail: processedData.submitterEmail || null,
@@ -475,7 +475,6 @@ export class SubmissionService {
       month: sanitizedData.month,
       day: sanitizedData.day,
       date: sanitizedData.date, // Keep for backward compatibility
-      category: sanitizedData.category || undefined,
       notes: sanitizedData.notes || undefined,
       submitterName: sanitizedData.submitterName || undefined,
       submitterEmail: sanitizedData.submitterEmail || undefined,

--- a/pages/share/[token].tsx
+++ b/pages/share/[token].tsx
@@ -72,11 +72,11 @@ const SharingPage = ({ token }: SharingPageProps) => {
   if (error || !validation) {
     return (
       <PublicLayout title="Error | Lazy Uncle">
-        <div className="mx-auto max-w-2xl text-center">
+        <div className="mx-auto max-w-2xl rounded-lg border border-rule bg-paper p-8 text-center text-ink shadow-sm">
           <div className="mb-6">
-            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-red-100">
+            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-rose-100">
               <svg
-                className="h-8 w-8 text-red-600"
+                className="h-8 w-8 text-rose-700"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -90,16 +90,16 @@ const SharingPage = ({ token }: SharingPageProps) => {
               </svg>
             </div>
           </div>
-          <h1 className="mb-4 text-2xl font-bold text-gray-900">
+          <h1 className="mb-4 font-display text-2xl font-semibold text-ink">
             Something went wrong
           </h1>
-          <p className="mb-6 text-gray-700">
+          <p className="mb-6 text-ink">
             We encountered an error while loading this sharing link. Please try
             again or contact the person who shared this link with you.
           </p>
           <button
             onClick={handleClose}
-            className="inline-flex items-center rounded-md bg-cyan-600 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-700 focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2 focus:outline-none"
+            className="inline-flex items-center rounded-md bg-accent px-4 py-2 text-sm font-medium text-white transition hover:bg-accent-deep focus:outline-hidden focus:ring-2 focus:ring-accent/40 focus:ring-offset-2"
           >
             Go to Lazy Uncle
           </button>
@@ -137,11 +137,11 @@ const SharingPage = ({ token }: SharingPageProps) => {
 
     return (
       <PublicLayout title={`${getErrorTitle()} | Lazy Uncle`}>
-        <div className="mx-auto max-w-2xl text-center">
+        <div className="mx-auto max-w-2xl rounded-lg border border-rule bg-paper p-8 text-center text-ink shadow-sm">
           <div className="mb-6">
-            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-yellow-100">
+            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-amber-100">
               <svg
-                className="h-8 w-8 text-yellow-600"
+                className="h-8 w-8 text-amber-700"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -155,23 +155,23 @@ const SharingPage = ({ token }: SharingPageProps) => {
               </svg>
             </div>
           </div>
-          <h1 className="mb-4 text-2xl font-bold text-gray-900">
+          <h1 className="mb-4 font-display text-2xl font-semibold text-ink">
             {getErrorTitle()}
           </h1>
-          <p className="mb-6 text-gray-600">{getErrorDescription()}</p>
+          <p className="mb-6 text-ink">{getErrorDescription()}</p>
           <div className="space-y-4">
             <button
               onClick={handleClose}
-              className="inline-flex items-center rounded-md bg-cyan-600 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-700 focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2 focus:outline-none"
+              className="inline-flex items-center rounded-md bg-accent px-4 py-2 text-sm font-medium text-white transition hover:bg-accent-deep focus:outline-hidden focus:ring-2 focus:ring-accent/40 focus:ring-offset-2"
             >
               Go to Lazy Uncle
             </button>
-            <div className="text-sm text-gray-500">
+            <div className="text-sm text-ink-soft">
               <p>
                 Want to create your own birthday list?{" "}
                 <Link
                   href="/"
-                  className="font-medium text-cyan-600 hover:text-cyan-500"
+                  className="font-medium text-accent-deep underline underline-offset-4 hover:text-accent"
                 >
                   Sign up for free
                 </Link>
@@ -196,31 +196,32 @@ const SharingPage = ({ token }: SharingPageProps) => {
         sharingLink.ownerName || "someone"
       } keep track of important birthdays by adding birthday information.`}
     >
-      <div className="mx-auto max-w-4xl">
-        {/* Header Section */}
+      <div className="mx-auto max-w-6xl">
         <div className="mb-8 text-center">
-          <h1 className="mb-2 text-3xl font-bold text-white">
-            Add a Birthday
+          <h1 className="mb-2 font-display text-3xl font-semibold text-ink">
+            Add a birthday
             {sharingLink.ownerName && (
-              <span className="block text-2xl font-normal text-white">
+              <span className="block text-2xl font-normal text-ink-soft">
                 for {sharingLink.ownerName}
               </span>
             )}
           </h1>
           {sharingLink.description && (
-            <p className="mb-4 text-lg white">{sharingLink.description}</p>
+            <p className="mb-4 text-lg text-ink-soft">
+              {sharingLink.description}
+            </p>
           )}
-          <p className="text-white max-w-2xl mx-auto">
+          <p className="mx-auto max-w-2xl text-ink">
             Help keep track of important birthdays by adding the details below.
             Your submission will be reviewed before being added to the birthday
             list.
           </p>
           {isExpiringSoon && (
-            <div className="mt-4 rounded-md bg-yellow-50 p-4">
+            <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-4 text-left">
               <div className="flex">
                 <div className="shrink-0">
                   <svg
-                    className="h-5 w-5 text-yellow-400"
+                    className="h-5 w-5 text-amber-600"
                     viewBox="0 0 20 20"
                     fill="currentColor"
                   >
@@ -232,7 +233,7 @@ const SharingPage = ({ token }: SharingPageProps) => {
                   </svg>
                 </div>
                 <div className="ml-3">
-                  <p className="text-sm text-yellow-800">
+                  <p className="text-sm text-amber-900">
                     This sharing link expires on{" "}
                     {expiresAt.toLocaleDateString(undefined, {
                       weekday: "long",
@@ -250,8 +251,7 @@ const SharingPage = ({ token }: SharingPageProps) => {
           )}
         </div>
 
-        {/* Form Section */}
-        <div className="rounded-lg bg-white p-8 lg:py-12 shadow-sm ring-1 ring-gray-200">
+        <div className="rounded-lg border border-rule bg-paper p-4 shadow-sm md:p-6 lg:p-8">
           <BirthdaySubmissionForm
             token={token}
             onSuccess={() => {}}
@@ -259,18 +259,23 @@ const SharingPage = ({ token }: SharingPageProps) => {
           />
         </div>
 
-        {/* Info Section */}
-        <div className="mt-8 text-center text-sm text-white">
+        <div className="mt-8 text-center text-sm text-ink-soft">
           <p>
             Powered by{" "}
-            <Link href="/" className="font-medium">
+            <Link
+              href="/"
+              className="font-medium text-accent-deep underline underline-offset-4 hover:text-accent"
+            >
               Lazy Uncle
             </Link>{" "}
-            - The easy way to keep track of birthdays
+            — the easy way to keep track of birthdays
           </p>
           <p className="mt-2">
             Want to create your own birthday list?{" "}
-            <Link href="/" className="font-medium">
+            <Link
+              href="/"
+              className="font-medium text-accent-deep underline underline-offset-4 hover:text-accent"
+            >
               Sign up for free
             </Link>
           </p>


### PR DESCRIPTION
## Summary

Two-part change to improve the sharing-link flow:

1. **Backend** — move \`category\` from the per-submission form to the sharing link itself. Link owners pick a category when creating a link; every submission through that link inherits it server-side. Migration \`0003_neat_hitman.sql\` adds a nullable \`category\` text column to \`SharingLink\`.
2. **UI** — replace the stacked-card layouts on \`/birthdays\` (sharing links + pending submissions) with denser tables, rebuild the \`/share/[token]\` page to be readable (it was rendering white text on the cream global background) and to enter birthdays as a tabular grid instead of one card per entry.

Also cleaned up: duplicate \`SUBMIT_BIRTHDAY_MUTATION\` definition in \`BirthdaySubmissionForm\` now imports the shared one from \`graphql/Sharing.ts\`. Dropped the \`relationship\` field from the submission form (it was collected but never made it onto the imported Birthday record).

## Test plan

- [ ] On \`/birthdays\`, the "Birthday sharing links" section renders as a table
- [ ] Creating a sharing link with a Category persists and shows the badge in the table
- [ ] On \`/share/<token>\`, text is dark/readable on the cream background; entries can be added as table rows
- [ ] Submitting through that link results in a pending submission whose category matches the link's category
- [ ] The "Birthday submissions" section on \`/birthdays\` renders as a table; expand/import/reject all work; duplicate-warning sub-row appears when applicable
- [ ] \`bunx vitest run\` — all 281 tests pass
- [ ] \`bun lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Birthday submissions now include an optional notes field (max 500 characters).
  * Sharing links now support an optional category field.
  * Redesigned submission review and sharing link management interfaces with table-based layouts.

* **Style**
  * Updated theme colors and typography throughout the application.
  * Refreshed header logo and footer styling.
  * Enhanced UI layouts for improved data display and organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michaelbonner/lazy-uncle/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->