### PR TITLE
Show current date on mobile Today divider line

### DIFF
--- a/components/BirthdayRow.tsx
+++ b/components/BirthdayRow.tsx
@@ -291,9 +291,12 @@ const BirthdayRow: FC<Props> = ({
             </p>
           </button>
         ) : (
-          <div>
+          <div className="flex w-full items-center justify-between">
             <p className="flex items-center space-x-2 text-sm text-ink-muted">
               <span>{birthday.name}</span>
+            </p>
+            <p className="text-xl font-medium text-accent-deep">
+              {format(birthDate, "MMM d")}
             </p>
           </div>
         )}


### PR DESCRIPTION
The mobile Today separator only displayed the "Today" label while
birthday rows and the desktop divider show a date. Add the formatted
current date on the right so the divider matches the other rows.

https://claude.ai/code/session_018t2cu9UNkBKMqQrEwLvQ3R

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile birthday information display with enhanced layout structure for better visual hierarchy and readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michaelbonner/lazy-uncle/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->