### PR TITLE
Copy scripts and lib into the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,12 @@ COPY --from=build /app/.next/static ./app/.next/static
 COPY --from=build /app/public ./app/public
 COPY --from=build /app/drizzle ./drizzle
 COPY --from=build /app/drizzle.config.ts ./drizzle.config.ts
+
+# The Dokploy schedules `docker exec` into this container and run the
+# package.json job scripts, which Next.js does not trace into standalone.
+COPY --from=build /app/scripts ./scripts
+COPY --from=build /app/lib ./lib
+
 COPY --from=build /app/package.json ./package.json
 
 EXPOSE 3000


### PR DESCRIPTION
Fixes the four Dokploy schedules for this project, which have failed every run since the alpine image switch deployed on Aug 4.

## Two separate failures

**1. `bash` is not in the image.** `oven/bun:1-alpine` has no bash, so every run died before starting:

```
exec: "bash": executable file not found in $PATH
```

**2. The job scripts are not in the image.** Fixing the shell alone only moved the failure:

```
sh -c bun cleanup:links
error: Module not found "scripts/cleanup-expired-links.ts"
```

The runtime stage received only the traced Next.js standalone output plus `drizzle/`, so `scripts/` and `lib/` were never copied.

## Change

Two `COPY` lines in the runtime stage. Import tracing shows the four scripts reach only into `lib/` and `drizzle/` (already copied); the one outward reference from `lib/` is a type-only `import type { AppRouter }` in `lib/trpc.ts`, which is stripped at runtime and is not in these scripts' chain. Every runtime package (`drizzle-orm`, `pg`, `resend`, `nodemailer`, `@paralleldrive/cuid2`) is already in `dependencies`, so the `--production` node_modules stage covers them. No `tsconfig.json` is needed — there are no path aliases.

Cost: 164KB (`scripts/` 44K, `lib/` 120K) on a 987MB image.

## Done outside this PR

The `shellType` on all four schedules was changed from `bash` to `sh` in Dokploy. That is stored in Dokploy, not in this repo, and is already applied. Staging has no schedules.

## Verification

Built the image, ran it against Postgres on a Docker network, and invoked each job exactly as Dokploy does (`docker exec <container> sh -c "<command>"`). All four exit 0:

```
$ bun scripts/send-birthday-reminders.ts   → Processing birthday reminders for 8/6... Done.
$ bun scripts/send-daily-summaries.ts      → Processed daily summary notifications for 0 eligible users
$ bun scripts/cleanup-expired-links.ts     → Cleaned up 0 expired sharing link(s).
$ bun scripts/cleanup-old-submissions.ts   → Cleaned up 0 old rejected submission(s).
```

Migrations still run on container start, so the existing `CMD` is unaffected. `bun run lint` clean; `bun run test` 298 passed across 21 files.

## After merge

The schedules stay red until this image is built and deployed. `schedule.runManually` on "Cleanup expired links" is the safe way to confirm — it is idempotent and runs hourly anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package job scripts and their required dependencies are now available within the runtime container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->